### PR TITLE
Make Overpass Ultra query self-descriptive

### DIFF
--- a/visualizations/curb_type
+++ b/visualizations/curb_type
@@ -1,4 +1,5 @@
 ---
+# Styled Overpass query for use in Ultra (https://overpass-ultra.us)
 style:
   extends: https://styles.trailsta.sh/protomaps-black.json
   layers:

--- a/visualizations/roadway_sidewalk_tagging
+++ b/visualizations/roadway_sidewalk_tagging
@@ -1,4 +1,5 @@
 ---
+# Styled Overpass query for use in Ultra (https://overpass-ultra.us)
 style:
   extends: https://styles.trailsta.sh/protomaps-black.json
   layers:
@@ -47,6 +48,7 @@ style:
         line-width: 2
         line-color: "#FBB13C"
 ---
+
 [bbox:{{bbox}}];
 (
   way[~"sidewalk"~"separate|yes|no"];

--- a/visualizations/tactile_paving
+++ b/visualizations/tactile_paving
@@ -1,4 +1,5 @@
 ---
+# Styled Overpass query for use in Ultra (https://overpass-ultra.us)
 style:
   extends: https://styles.trailsta.sh/protomaps-black.json
   layers:


### PR DESCRIPTION
I had saved this bookmark a while ago, but didn't look into it right away, so when I finally was able to process it I had lost the context of how I came to it; fortunately I happened to already know about Overpass Turbo and Overpass Ultra, so I managed to use this as intended. However, it would have been nice if no guesswork was needed.

This PR introduces a comment at the top of the file explaining what it is and how to use it. I'd be happy to add a similar entry to the other queries, but wanted to make sure this would be OK before spending time doing so.